### PR TITLE
Clearer options around reporting.

### DIFF
--- a/src/inc/class-cloudflare-stream-settings.php
+++ b/src/inc/class-cloudflare-stream-settings.php
@@ -114,7 +114,7 @@ class Cloudflare_Stream_Settings {
 
 			add_settings_field(
 				self::OPTION_HEAP_ANALYTICS,
-				'Opt out of Heap Analytics',
+				'Opt-out of Heap Analytics',
 				array( $this, 'reporting_opt_out_cb' ),
 				self::SETTING_PAGE,
 				self::SETTING_SECTION_REPORTING
@@ -261,7 +261,8 @@ class Cloudflare_Stream_Settings {
 	 * @since 1.0.0
 	 */
 	public function settings_section_reporting() {
-		echo '<p>By choosing to share diagnostic and usage data, you help improve Cloudflare Stream for WordPress. You can opt out at any time by unchecking the box below.</p>';
+		echo '<p>By choosing to share diagnostic and usage data, you help improve Cloudflare Stream for WordPress.</p>'
+		. '<p>You can opt-out at any time by checking the box below.</p>';
 	}
 
 	/**


### PR DESCRIPTION
In the admin settings for Cloudflare Stream Settings, I’m presented with the following option:

> By choosing to share diagnostic and usage data, you help improve Cloudflare Stream for WordPress. You can opt out at any time by unchecking the box below.
> 
> Opt out of Heap Analytics ☑

The explanation, and the setting contradict each other. It’s confusing as to whether ticking opts-in or opts-out.

When encountering a tick box, it’s typically understood that:
☑ = Yes / do it
☐ = No / don't do it

The plug-in's explanation to opt-out:

> opt out… by un-checking

The plug-in's actual option:

> Opt out… ☑


Reviewing [heap.js](https://github.com/cloudflare/stream-wordpress/blob/e949271e91bb402d5befe73acd099fe73b1e0fae/src/heap.js), I can see that **unchecking** the box actually **opts-in** to analytics.
